### PR TITLE
count dispatches

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-debug-webapp/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-debug-webapp/releases/tag/v0.1.0",
     "icon_path": "assets/starter-template-icon.svg",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "min_server_version": "5.12.0",
     "webapp": {
         "bundle_path": "webapp/dist/main.js"

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -13,13 +13,22 @@ const globalStats = {
 };
 
 export default class Plugin {
+    private unsubscribe?: () => void;
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
     public async initialize(registry: PluginRegistry, store: Store<GlobalState, Action<Record<string, unknown>>>) {
         window.webappDebugStore = store;
-        store.subscribe(() => {
+        this.unsubscribe = store.subscribe(() => {
             globalStats.NumDispatches++;
         });
         window.logStoreStatistics = () => logStoreStatistics(store);
+    }
+
+    public deinitialize() {
+        if (this.unsubscribe) {
+            this.unsubscribe();
+            delete this.unsubscribe;
+        }
     }
 }
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -7,16 +7,25 @@ import manifest from './manifest';
 // eslint-disable-next-line import/no-unresolved
 import {PluginRegistry} from './types/mattermost-webapp';
 
+const globalStats = {
+    Start: Date.now(),
+    NumDispatches: 0,
+};
+
 export default class Plugin {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
     public async initialize(registry: PluginRegistry, store: Store<GlobalState, Action<Record<string, unknown>>>) {
         window.webappDebugStore = store;
+        store.subscribe(() => {
+            globalStats.NumDispatches++;
+        });
         window.logStoreStatistics = () => logStoreStatistics(store);
     }
 }
 
 function logStoreStatistics(store: any) {
     const state = store.getState();
+    const now = Date.now();
 
     const currentChannelId = state.entities.channels.currentChannelId;
     const currentTeamId = state.entities.teams.currentTeamId;
@@ -33,6 +42,10 @@ function logStoreStatistics(store: any) {
         'Posts (current channel)': Object.values(state.entities.posts.posts).filter((post: any) => post.channel_id === currentChannelId)?.length,
         'Visible DMs (from preferences)': Object.values(state.entities.preferences.myPreferences).filter((preference: any) => preference.category === 'direct_channel_show' && preference.value === 'true')?.length,
         'Visible GMs (from preferences)': Object.values(state.entities.preferences.myPreferences).filter((preference: any) => preference.category === 'group_channel_show' && preference.value === 'true')?.length,
+        Start: globalStats.Start,
+        NumDispatches: globalStats.NumDispatches,
+        Now: now,
+        DispatchesPerSecond: globalStats.NumDispatches / (Math.abs(now - globalStats.Start) / 1000),
     };
 
     // eslint-disable-next-line no-console


### PR DESCRIPTION
#### Summary
Keep track of when the plugin started and the number of dispatches that have occurred since that time. Include these stats, the current time, and the computed number of dispatches per second in the stats emitted by `window.logStoreStatistics`.